### PR TITLE
Adjusting repeated character filter

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -236,7 +236,7 @@ class AntiSpam extends Extension {
         to block spam of over 3 consecutive same punctuation
         instead of only blocking over 3 repeated word characters
         */
-        this._currentChatMessage.content = this._currentChatMessage.content.replace(/([a-zA-Z])\1{3,}|([0-9])\2{4,}|([!-\/:-@\[-`{-~])\3{3,}/ig, "$1$1$2$2$2$2$3");
+        this._currentChatMessage.content = this._currentChatMessage.content.replace(/([a-zA-Z])\1{3,}|([0-9])\2{4,}|([!-\/:-@\[-`{-~])\3{3,}/ig, "$1$1$1$2$2$2$2$3");
         return false;
     }
 

--- a/app/index.ts
+++ b/app/index.ts
@@ -230,7 +230,13 @@ class AntiSpam extends Extension {
     }
 
     private trimRepeatedLetters(): boolean {
-        this._currentChatMessage.content = this._currentChatMessage.content.replace(/(.)\1{3,}/ig, "$1$1");
+        /*
+        To reach consistency between TSL and TShock the repeated character filter has been adjusted as well
+        to allow 4 same digits in a row ([i:4444] and 9999 pass) and 
+        to block spam of over 3 consecutive same punctuation
+        instead of only blocking over 3 repeated word characters
+        */
+        this._currentChatMessage.content = this._currentChatMessage.content.replace(/([a-zA-Z])\1{3,}|([0-9])\2{4,}|([!-\/:-@\[-`{-~])\3{3,}/ig, "$1$1$2$2$2$2$3");
         return false;
     }
 

--- a/app/index.ts
+++ b/app/index.ts
@@ -232,7 +232,7 @@ class AntiSpam extends Extension {
     private trimRepeatedLetters(): boolean {
         /*
         To reach consistency between TSL and TShock the repeated character filter has been adjusted as well
-        to allow 4 same digits in a row ([i:4444] and 9999 pass) and 
+        to allow 4 same digits in a row ([i:4444] and 9999 pass) and
         to block spam of over 3 consecutive same punctuation
         instead of only blocking over 3 repeated word characters
         Now also blocking consecutive non-ASCII letter spam

--- a/app/index.ts
+++ b/app/index.ts
@@ -235,8 +235,9 @@ class AntiSpam extends Extension {
         to allow 4 same digits in a row ([i:4444] and 9999 pass) and 
         to block spam of over 3 consecutive same punctuation
         instead of only blocking over 3 repeated word characters
+        Now also blocking consecutive non-ASCII letter spam
         */
-        this._currentChatMessage.content = this._currentChatMessage.content.replace(/([a-zA-Z])\1{3,}|([0-9])\2{4,}|([!-\/:-@\[-`{-~])\3{3,}/ig, "$1$1$1$2$2$2$2$3");
+        this._currentChatMessage.content = this._currentChatMessage.content.replace(/(\d)\1{4,}|([^\d])\2{3,}/ig, "$1$1$1$1$2$2$2");
         return false;
     }
 


### PR DESCRIPTION
Made same changes to the TSL repeated character filter as in the TShock repeated characters filter. The behavior should become the same as in TShock (more info, cf https://github.com/popstarfreas/AntiSpam/commit/e70410553c2374724350f99025b90454ed9f1630), with the difference that in TSL the repeated characters are still trimmed like in the old filter.